### PR TITLE
Fix ruby syntax in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Gem Version](https://badge.fury.io/rb/graphql_playground-rails.svg)](https://badge.fury.io/rb/graphql_playground-rails)
 # GraphqlPlayground::Rails
 A blatant copy of [GraphiQL::Rails](https://github.com/rmosolgo/graphiql-rails) with much less functionality but with [GraphQL Playground](https://github.com/graphcool/graphql-playground) instead.
@@ -40,7 +41,7 @@ end
 # All config options have a default that sould work out of the box
 GraphqlPlayground::Rails.configure do |config|
   config.headers = {
-    'X-Auth-Header' => (view_context) -> { "123" }
+    'X-Auth-Header' => ->(view_context) { "123" }
   }
   config.title = "Playground"
   config.csrf = true


### PR DESCRIPTION
Fix a syntax error in README.md.

```
[snip]/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:55:in `load': [snip]/config/initializers/graphql_playground.rb:3: syntax error, unexpected ->, expecting '}' (SyntaxError)
...th-Header' => (view_context) -> { "123" }
...                             ^~
[snip]/config/initializers/graphql_playground.rb:4: syntax error, unexpected '}', expecting end
```