### PR TITLE
README: schema.polling.enable is the correct option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ GraphqlPlayground::Rails.configure do |config|
   config.playground_css_url = "/assets/playground.css"
   # see: https://github.com/prisma-labs/graphql-playground#settings
   config.settings = {
-    "editor.polling.enable": false
+    "schema.polling.enable": false
   }
 end
 ```


### PR DESCRIPTION
`editor.polling.enable` does not exist in the current version of graphql-playground (I'm not sure if this was valid in previous versions). The correct option seems to be `schema.polling.enable`.
https://github.com/graphql/graphql-playground#properties